### PR TITLE
Use IAsyncDisposable instead of IDisposable, minor async issue fixes

### DIFF
--- a/src/BlazorFabric.BaseComponent/ResponsiveFabricComponentBase.cs
+++ b/src/BlazorFabric.BaseComponent/ResponsiveFabricComponentBase.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace BlazorFabric
 {
-    public class ResponsiveFabricComponentBase : FabricComponentBase, IDisposable
+    public class ResponsiveFabricComponentBase : FabricComponentBase, IAsyncDisposable
     {
         private string _resizeRegistration;
 
@@ -59,7 +59,7 @@ namespace BlazorFabric
             return Task.CompletedTask;
         }
 
-        public virtual async void Dispose()
+        public virtual async ValueTask DisposeAsync()
         {
             if (_resizeRegistration != null)
             {

--- a/src/BlazorFabric.Button/ButtonBase.cs
+++ b/src/BlazorFabric.Button/ButtonBase.cs
@@ -12,7 +12,7 @@ using System.Windows.Input;
 
 namespace BlazorFabric
 {
-    public class ButtonBase : FabricComponentBase, IDisposable
+    public class ButtonBase : FabricComponentBase, IAsyncDisposable
     {
         internal ButtonBase()
         {
@@ -377,7 +377,7 @@ namespace BlazorFabric
 
         }
 
-        public async void Dispose()
+        public async ValueTask DisposeAsync()
         {
             if (_registrationToken != null)
                 await DeregisterListFocusAsync();

--- a/src/BlazorFabric.Callout/CalloutContent.razor.cs
+++ b/src/BlazorFabric.Callout/CalloutContent.razor.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace BlazorFabric
 {
-    public partial class CalloutContent : FabricComponentBase, IDisposable
+    public partial class CalloutContent : FabricComponentBase, IAsyncDisposable
     {
 
         [Inject] private IJSRuntime JSRuntime { get; set; }
@@ -184,7 +184,7 @@ namespace BlazorFabric
         }
 
 
-        public async void Dispose()
+        public async ValueTask DisposeAsync()
         {
             if (eventHandlerIds != null)
                 await JSRuntime.InvokeAsync<object>("BlazorFabricCallout.unregisterHandlers", eventHandlerIds);

--- a/src/BlazorFabric.ContextualMenu/ContextualMenu.razor.cs
+++ b/src/BlazorFabric.ContextualMenu/ContextualMenu.razor.cs
@@ -10,7 +10,7 @@ using System.Windows.Input;
 
 namespace BlazorFabric
 {
-    public partial class ContextualMenu : ResponsiveFabricComponentBase, IDisposable
+    public partial class ContextualMenu : ResponsiveFabricComponentBase, IAsyncDisposable
     {      
         [Parameter] public bool AlignTargetEdge { get; set; }
         //[Parameter] public string AriaLabel { get; set; }
@@ -140,10 +140,10 @@ namespace BlazorFabric
             await this.OnMenuOpened.InvokeAsync(this);
         }
 
-        public override void Dispose()
+        public override async ValueTask DisposeAsync()
         {
-            this.OnMenuDismissed.InvokeAsync(this);
-            base.Dispose();
+            await this.OnMenuDismissed.InvokeAsync(this);
+            await base.DisposeAsync();
         }
     }
 }

--- a/src/BlazorFabric.ContextualMenu/Internal/ContextualMenuItem.cs
+++ b/src/BlazorFabric.ContextualMenu/Internal/ContextualMenuItem.cs
@@ -80,6 +80,7 @@ namespace BlazorFabric.ContextualMenuInternal
         public void Dispose()
         {
             jsRuntime.InvokeAsync<object>("BlazorFabricContextualMenu.unregisterHandlers", eventHandlerIds);
+            enterTimer.Dispose();
         }
 
         public override Task SetParametersAsync(ParameterView parameters)

--- a/src/BlazorFabric.Dropdown/Dropdown.razor.cs
+++ b/src/BlazorFabric.Dropdown/Dropdown.razor.cs
@@ -226,9 +226,10 @@ namespace BlazorFabric
             return Task.CompletedTask;
         }
 
-        protected async Task DismissHandler()
+        protected Task DismissHandler()
         {
             isOpen = false;
+            return Task.CompletedTask;
         }
 
       

--- a/src/BlazorFabric.FocusTrapZone/FocusTrapZone.razor.cs
+++ b/src/BlazorFabric.FocusTrapZone/FocusTrapZone.razor.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace BlazorFabric
 {
-    public partial class FocusTrapZone : FabricComponentBase, IDisposable
+    public partial class FocusTrapZone : FabricComponentBase, IAsyncDisposable
     {
         protected static Stack<FocusTrapZone> _focusStack = new Stack<FocusTrapZone>();
 
@@ -89,7 +89,7 @@ namespace BlazorFabric
 
      
 
-        public async void Dispose()
+        public async ValueTask DisposeAsync()
         {
             if (_id != -1)
                 await jsRuntime.InvokeVoidAsync("BlazorFabricFocusTrapZone.unregister", _id);

--- a/src/BlazorFabric.FocusZone/FocusZone.razor.cs
+++ b/src/BlazorFabric.FocusZone/FocusZone.razor.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 namespace BlazorFabric
 {
 
-    public partial class FocusZone : FabricComponentBase, IDisposable
+    public partial class FocusZone : FabricComponentBase, IAsyncDisposable
     {
         [Inject] private IJSRuntime jsRuntime { get; set; }
 
@@ -74,13 +74,13 @@ namespace BlazorFabric
             return base.OnInitializedAsync();
         }
 
-        protected override void OnAfterRender(bool firstRender)
+        protected override async void OnAfterRender(bool firstRender)
         {
             if (firstRender)
             {
                 if (_registrationTask == null)
                 {
-                    RegisterFocusZoneAsync();
+                    await RegisterFocusZoneAsync();
                 }
                 else if (!_registrationTask.IsCompleted)
                 {
@@ -94,7 +94,7 @@ namespace BlazorFabric
                 if (_registrationId != -1 && updateFocusZone)
                 {
                     updateFocusZone = false;
-                    UpdateFocusZoneAsync();
+                    await UpdateFocusZoneAsync();
                 }
             }
             base.OnAfterRender(firstRender);
@@ -193,12 +193,12 @@ namespace BlazorFabric
         }
 
 
-        public async void Dispose()
+        public async ValueTask DisposeAsync()
         {
             if (_registrationId != -1)
             {                
                 //Debug.WriteLine("Trying to unregister focuszone");
-                UnregisterFocusZoneAsync();
+                await UnregisterFocusZoneAsync();
                 
             }
         }

--- a/src/BlazorFabric.List/List.razor.cs
+++ b/src/BlazorFabric.List/List.razor.cs
@@ -21,7 +21,7 @@ using BlazorFabric.BaseComponent.FocusStyle;
 
 namespace BlazorFabric
 {
-    public partial class List<TItem> : FabricComponentBase, IDisposable
+    public partial class List<TItem> : FabricComponentBase, IAsyncDisposable
     {
         //protected bool firstRender = false;
 
@@ -415,10 +415,10 @@ namespace BlazorFabric
             return listRules;
         }
 
-        public void ForceUpdate()
+        public async Task ForceUpdate()
         {
 
-            MeasureContainerAsync();
+            await MeasureContainerAsync();
         }
 
         private RenderFragment RenderPages(int startPage, int endPage, double leadingPadding = 0) => builder =>
@@ -580,7 +580,7 @@ namespace BlazorFabric
             _scrollDoneSubject.OnNext(Unit.Default);
         }
 
-        public async void Dispose()
+        public async ValueTask DisposeAsync()
         {
             //if (OnListScrollerHeightChanged.HasDelegate)
             //    await OnListScrollerHeightChanged.InvokeAsync((0, Data));

--- a/src/BlazorFabric.Modal/Modal.razor.cs
+++ b/src/BlazorFabric.Modal/Modal.razor.cs
@@ -9,7 +9,7 @@ using System.Timers;
 
 namespace BlazorFabric
 {
-    public partial class Modal : FabricComponentBase, IDisposable
+    public partial class Modal : FabricComponentBase, IAsyncDisposable
     {
         [Parameter]
         public string ContainerClass { get; set; }
@@ -199,7 +199,7 @@ namespace BlazorFabric
              return IsOpen;
         }
 
-        public async void Dispose()
+        public async ValueTask DisposeAsync()
         {
             _clearExistingAnimationTimer();
             if (_keydownRegistration != null)

--- a/src/BlazorFabric.Overlay/Overlay.razor
+++ b/src/BlazorFabric.Overlay/Overlay.razor
@@ -2,7 +2,7 @@
 @using Microsoft.AspNetCore.Components.Web
 @using Microsoft.JSInterop
 @inherits FabricComponentBase
-@implements IDisposable
+@implements IAsyncDisposable
 
 <div class=@("mediumFont ms-Overlay " + (IsDarkThemed ? "ms-Overlay--dark" : "") + " " + ClassName)
      @onclick="OnClick" />
@@ -26,7 +26,7 @@
 
     }
 
-    public async void Dispose()
+    public async ValueTask DisposeAsync()
     {
         await JSRuntime.InvokeVoidAsync("BlazorFabricBaseComponent.enableBodyScroll");
     }

--- a/src/BlazorFabric.Panel/Panel.razor.cs
+++ b/src/BlazorFabric.Panel/Panel.razor.cs
@@ -11,7 +11,7 @@ using System.Timers;
 
 namespace BlazorFabric
 {
-    public partial class Panel : FabricComponentBase, IDisposable
+    public partial class Panel : FabricComponentBase, IAsyncDisposable
     {
         [Inject]
         private IJSRuntime JSRuntime { get; set; }
@@ -398,7 +398,7 @@ namespace BlazorFabric
                 currentVisibility = PanelVisibilityState.AnimatingClosed;
                 // This StateHasChanged call was added because using a custom close button in NavigationTemplate did not cause a state change to occur.
                 // The result was that the animation class would not get added and the close transition would not show.  This is a hack to make it work.
-                InvokeAsync(StateHasChanged);
+                await InvokeAsync(StateHasChanged);
             }
 
             Debug.WriteLine($"Was: {previousVisibility}  Current:{currentVisibility}");
@@ -452,7 +452,7 @@ namespace BlazorFabric
             return IsBlocking && IsOpen;
         }
 
-        public async void Dispose()
+        public async ValueTask DisposeAsync()
         {
             _clearExistingAnimationTimer?.Invoke();
             if (_scrollerEventId != null)

--- a/src/BlazorFabric.Popup/Popup.razor.cs
+++ b/src/BlazorFabric.Popup/Popup.razor.cs
@@ -11,7 +11,7 @@ namespace BlazorFabric
     /**
      * This adds accessibility to Dialog and Panel controls
      */
-    public partial class Popup : FabricComponentBase, IDisposable
+    public partial class Popup : FabricComponentBase, IAsyncDisposable
     {
         [Parameter] public RenderFragment ChildContent { get; set; }
 
@@ -54,7 +54,7 @@ namespace BlazorFabric
             //return Task.CompletedTask;
         }
 
-        public async void Dispose()
+        public async ValueTask DisposeAsync()
         {
             if (_handleToLastFocusedElement != null)
             {

--- a/src/BlazorFabric.ResizeGroup/ResizeGroup.razor.cs
+++ b/src/BlazorFabric.ResizeGroup/ResizeGroup.razor.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace BlazorFabric
 {
-    public partial class ResizeGroup<TObject> : FabricComponentBase, IDisposable
+    public partial class ResizeGroup<TObject> : FabricComponentBase, IAsyncDisposable
     {
         [Inject] IJSRuntime jSRuntime { get; set; }
 
@@ -300,7 +300,7 @@ namespace BlazorFabric
 
         }
 
-        public async void Dispose()
+        public async ValueTask DisposeAsync()
         {
             try
             {

--- a/src/BlazorFabric.Tooltip/TooltipHost.razor.cs
+++ b/src/BlazorFabric.Tooltip/TooltipHost.razor.cs
@@ -204,6 +204,8 @@ namespace BlazorFabric
         {
             _dismissTimer.Stop();
             _openTimer.Stop();
+            _openTimer.Dispose();
+            _dismissTimer.Dispose();
             _dismissTimer = null;
             _openTimer = null;
 


### PR DESCRIPTION
- .NET Standard 2.1 provided IAsyncDisposable for disposing things in async way. `async void` is dangerous for it cannot be awaited, so there's no way to know whether the async operation completed and may cause operation cancelled unexpectedly
- Some async operations aren't awaited, this PR fixed them and tested ok

This PR was based on branch BasicList.